### PR TITLE
Don't hide Hypixel NPCs

### DIFF
--- a/src/main/java/me/sad/hideplayers/mixins/MixinRenderManager.java
+++ b/src/main/java/me/sad/hideplayers/mixins/MixinRenderManager.java
@@ -15,7 +15,7 @@ public abstract class MixinRenderManager {
     @Inject(at=@At("HEAD"), method = "shouldRender", cancellable = true)
     public void shouldRender(Entity entityIn, ICamera camera, double camX, double camY, double camZ, CallbackInfoReturnable<Boolean> cir) {
         if (entityIn instanceof EntityOtherPlayerMP) {
-            if (!HidePlayers.players.contains(entityIn.getName().toLowerCase()) && !HidePlayers.toggled) {
+            if (!HidePlayers.players.contains(entityIn.getName().toLowerCase()) && entityIn.getUniqueID().version() != 2 && !HidePlayers.toggled) { // hypixel's NPCs have UUIDv2
                 cir.setReturnValue(false);
             }
         }

--- a/src/main/java/me/sad/hideplayers/mixins/MixinRenderManager.java
+++ b/src/main/java/me/sad/hideplayers/mixins/MixinRenderManager.java
@@ -1,15 +1,11 @@
 package me.sad.hideplayers.mixins;
 
 import me.sad.hideplayers.HidePlayers;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityOtherPlayerMP;
 import net.minecraft.client.renderer.culling.ICamera;
-import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.entity.Entity;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;

--- a/src/main/resources/hideplayers.mixins.json
+++ b/src/main/resources/hideplayers.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "compatibilityLevel": "JAVA_8",
   "package": "me.sad.hideplayers.mixins",
-  "refmap": "hideplayers.refmap.json",
+  "refmap": "mixin.refmap.json",
   "mixins": ["MixinRenderManager"],
   "client": [],
   "server": []


### PR DESCRIPTION
Hypixel internally sends a UUIDv2 to the client to identify its NPCs, which can be used to make NPCs not hide when hiding players.
